### PR TITLE
Multiple skip take

### DIFF
--- a/commercetools.Sdk/IntegrationTests/commercetools.Sdk.IntegrationTests/LinqProviderTest.cs
+++ b/commercetools.Sdk/IntegrationTests/commercetools.Sdk.IntegrationTests/LinqProviderTest.cs
@@ -1,0 +1,113 @@
+using System.Linq;
+using System.Threading.Tasks;
+using commercetools.Sdk.Client;
+using commercetools.Sdk.Domain;
+using commercetools.Sdk.Domain.Categories;
+using commercetools.Sdk.Domain.ProductProjections;
+using Xunit;
+
+namespace commercetools.Sdk.IntegrationTests
+{
+    [Collection("Integration Tests")]
+    public class LinqProviderTest
+    {
+        private readonly IClient client;
+
+        public LinqProviderTest(ServiceProviderFixture serviceProviderFixture)
+        {
+            this.client = serviceProviderFixture.GetService<IClient>();
+        }
+
+        [Fact]
+        public async Task QueryTakeSkipTake()
+        {
+            var query = from c in this.client.Query<Category>()
+                where c.Key == "category-foo"
+                select c;
+
+            query = query.Take(3).Skip(1).Take(4);
+
+            var parameters = (query.Provider as ClientQueryProvider<Category>)?.Command.QueryParameters as QueryCommandParameters;
+
+            Assert.Equal(1, parameters?.Offset);
+            Assert.Equal(2, parameters?.Limit);
+        }
+
+        [Fact]
+        public async Task QuerySkipTakeSkip()
+        {
+            var query = from c in this.client.Query<Category>()
+                where c.Key == "category-foo"
+                select c;
+
+            query = query.Skip(4).Take(3).Skip(1);  // that should yield 3 items from offset 5
+
+            var parameters = (query.Provider as ClientQueryProvider<Category>)?.Command.QueryParameters as QueryCommandParameters;
+
+            Assert.Equal(5, parameters?.Offset);
+            Assert.Equal(2, parameters?.Limit);
+
+        }
+
+        [Fact]
+        public async Task QueryTakeSkip()
+        {
+            var query = from c in this.client.Query<Category>()
+                where c.Key == "category-foo"
+                select c;
+
+            query = query.Take(3).Skip(2);          // that should yield 1 item from offset 2
+
+            var parameters = (query.Provider as ClientQueryProvider<Category>)?.Command.QueryParameters as QueryCommandParameters;
+
+            Assert.Equal(2, parameters?.Offset);
+            Assert.Equal(1, parameters?.Limit);
+        }
+
+        [Fact]
+        public async Task SearchTakeSkipTake()
+        {
+            var query = from c in this.client.SearchProducts()
+                where c.Key == "category-foo"
+                select c;
+
+            query = query.Take(3).Skip(1).Take(4);
+
+            var parameters = (query.Provider as ClientProductProjectionSearchProvider)?.Command.SearchParameters as ProductProjectionSearchParameters;
+
+            Assert.Equal(1, parameters?.Offset);
+            Assert.Equal(2, parameters?.Limit);
+        }
+
+        [Fact]
+        public async Task SearchSkipTakeSkip()
+        {
+            var query = from c in this.client.SearchProducts()
+                where c.Key == "category-foo"
+                select c;
+
+            query = query.Skip(4).Take(3).Skip(1);  // that should yield 3 items from offset 5
+
+            var parameters = (query.Provider as ClientProductProjectionSearchProvider)?.Command.SearchParameters as ProductProjectionSearchParameters;
+
+            Assert.Equal(5, parameters?.Offset);
+            Assert.Equal(2, parameters?.Limit);
+
+        }
+
+        [Fact]
+        public async Task SearchTakeSkip()
+        {
+            var query = from c in this.client.SearchProducts()
+                where c.Key == "category-foo"
+                select c;
+
+            query = query.Take(3).Skip(2);          // that should yield 1 item from offset 2
+
+            var parameters = (query.Provider as ClientProductProjectionSearchProvider)?.Command.SearchParameters as ProductProjectionSearchParameters;
+
+            Assert.Equal(2, parameters?.Offset);
+            Assert.Equal(1, parameters?.Limit);
+        }
+    }
+}

--- a/commercetools.Sdk/commercetools.Sdk.Client/SearchCommandExtensions.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Client/SearchCommandExtensions.cs
@@ -207,16 +207,7 @@ namespace commercetools.Sdk.Client
         {
             if (command.SearchParameters != null && command.SearchParameters is IPageable pageableParams)
             {
-                // Set limit to lowest value
-                // Case: query.Take(5).Take(10) should still yield only 5 items
-                if (pageableParams.Limit == null)
-                {
-                    pageableParams.Limit = limit;
-                }
-                else
-                {
-                    pageableParams.Limit = Math.Min(pageableParams.Limit.Value, limit);
-                }
+                pageableParams.Limit = limit;
             }
 
             return command;
@@ -226,26 +217,7 @@ namespace commercetools.Sdk.Client
         {
             if (command.SearchParameters != null && command.SearchParameters is IPageable pageableParams)
             {
-                // Sum all skips together
-                // Case: query.Skip(5).Skip(10) should result in an offset of 15
-                if (pageableParams.Offset == null)
-                {
-                    pageableParams.Offset = offset;
-                }
-                else
-                {
-                    pageableParams.Offset += offset;
-                }
-
-                // Case: query.Take(3).Skip(2) should yield only 1 item
-                // Case: query.Take(2).Skip(1).Take(2) should yield 0 items
-                // Case: query.Skip(3).Take(1).Skip(1) should yield 0 items
-                // This case is only of relevance if at least one Take operation was done beforehand
-                if (pageableParams.Limit != null)
-                {
-                    pageableParams.Limit -= offset;
-                    pageableParams.Limit = Math.Max(0, pageableParams.Limit.Value);
-                }
+                pageableParams.Offset = offset;
             }
 
             return command;


### PR DESCRIPTION
Added a test for #59 

Also moved the logic for offset/limit from SearchCommandExtension to the Search provider. Cause Offset and Limit have a defined behavior for the command where as take and skip implement the behavior expected from LINQ