### PR TITLE
Fix a bug when evaluating expressions with static fields

### DIFF
--- a/commercetools.Sdk/Tests/commercetools.Sdk.Linq.Tests/QueryPredicateTests.cs
+++ b/commercetools.Sdk/Tests/commercetools.Sdk.Linq.Tests/QueryPredicateTests.cs
@@ -636,5 +636,15 @@ namespace commercetools.Sdk.Linq.Tests
             string result = queryPredicateExpressionVisitor.Render(expression);
             Assert.Equal("masterData(published = false)", result);
         }
+
+        private static readonly string CustomerId = "59e22bf2-d5f5-4b8c-b78f-bb66cf28d4fe";
+        [Fact]
+        public void ExpressionEvaluationWithStaticFields()
+        {
+            Expression<Func<Customer, bool>> expression = x => x.Email == CustomerId;
+            IQueryPredicateExpressionVisitor queryPredicateExpressionVisitor = this.linqFixture.GetService<IQueryPredicateExpressionVisitor>();
+            string result = queryPredicateExpressionVisitor.Render(expression);
+            Assert.Equal("email = \"59e22bf2-d5f5-4b8c-b78f-bb66cf28d4fe\"", result);
+        }
     }
 }

--- a/commercetools.Sdk/Tests/commercetools.Sdk.Linq.Tests/QueryPredicateTests.cs
+++ b/commercetools.Sdk/Tests/commercetools.Sdk.Linq.Tests/QueryPredicateTests.cs
@@ -641,10 +641,10 @@ namespace commercetools.Sdk.Linq.Tests
         [Fact]
         public void ExpressionEvaluationWithStaticFields()
         {
-            Expression<Func<Customer, bool>> expression = x => x.Email == CustomerId;
+            Expression<Func<Customer, bool>> expression = x => x.Id == CustomerId;
             IQueryPredicateExpressionVisitor queryPredicateExpressionVisitor = this.linqFixture.GetService<IQueryPredicateExpressionVisitor>();
             string result = queryPredicateExpressionVisitor.Render(expression);
-            Assert.Equal("email = \"59e22bf2-d5f5-4b8c-b78f-bb66cf28d4fe\"", result);
+            Assert.Equal("id = \"59e22bf2-d5f5-4b8c-b78f-bb66cf28d4fe\"", result);
         }
     }
 }

--- a/commercetools.Sdk/commercetools.Sdk.Linq/Query/Converters/ConstantPredicateVisitorConverter.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Linq/Query/Converters/ConstantPredicateVisitorConverter.cs
@@ -45,14 +45,13 @@ namespace commercetools.Sdk.Linq.Query.Converters
             }
 
             MemberExpression memberExpression = expression as MemberExpression;
-            FieldInfo fieldInfo = memberExpression.Member as FieldInfo;
 
-            if (fieldInfo != null && fieldInfo.IsStatic)
+            if (memberExpression?.Expression.NodeType == ExpressionType.Constant)
             {
                 return true;
             }
 
-            if (memberExpression?.Expression.NodeType == ExpressionType.Constant)
+            if (memberExpression?.Member is FieldInfo info && info.IsStatic)
             {
                 return true;
             }

--- a/commercetools.Sdk/commercetools.Sdk.Linq/Query/Converters/ConstantPredicateVisitorConverter.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Linq/Query/Converters/ConstantPredicateVisitorConverter.cs
@@ -1,6 +1,7 @@
-﻿using System.Globalization;
+﻿using commercetools.Sdk.Linq.Query.Visitors;
+using System.Globalization;
 using System.Linq.Expressions;
-using commercetools.Sdk.Linq.Query.Visitors;
+using System.Reflection;
 
 namespace commercetools.Sdk.Linq.Query.Converters
 {
@@ -44,6 +45,13 @@ namespace commercetools.Sdk.Linq.Query.Converters
             }
 
             MemberExpression memberExpression = expression as MemberExpression;
+            FieldInfo fieldInfo = memberExpression.Member as FieldInfo;
+
+            if (fieldInfo != null && fieldInfo.IsStatic)
+            {
+                return true;
+            }
+
             if (memberExpression?.Expression.NodeType == ExpressionType.Constant)
             {
                 return true;


### PR DESCRIPTION
When evaluating something like

```
private static readonly string CustomerId = "59e22bf2-d5f5-4b8c-b78f-bb66cf28d4fe";
[...]
QueryCommand<Customer> customerQuery = new QueryCommand<Customer>();
customerQuery.Where(x => x.Email == CustomerId);
```

Will lead into an exception

``` 
System.NullReferenceException : Object reference not set to an instance of an object.

ConstantPredicateVisitorConverter.IsVariable(Expression expression) line 55
```

Debugging the problem I found that there is no Expression when it is a field. (memberExpression?.Expression == null)

The fix will check whether we have a Field and also checks whether it is static.

I also provided a Unit Test which will fail when you comment out the fix. Everyone else is still working.

I also manually tested it with different kind of member variables, such as consts, readonly, not readonly and so on. Everything still working.