### PR TITLE
Added a fix for bad formatting / missing quotes when querying with datetimes

### DIFF
--- a/commercetools.Sdk/Tests/commercetools.Sdk.Linq.Tests/QueryPredicateTests.cs
+++ b/commercetools.Sdk/Tests/commercetools.Sdk.Linq.Tests/QueryPredicateTests.cs
@@ -691,5 +691,17 @@ namespace commercetools.Sdk.Linq.Tests
             string result2 = queryPredicateExpressionVisitor.Render(expression);
             Assert.Equal("orderNumber not in (\"5\", \"10\", \"15\")", result2);
         }
+
+        [Fact]
+        public void ExpressionWithDateTimeFilters()
+        {
+            DateTime startDate = new DateTime(2020, 11, 21);
+            DateTime endDate = startDate.AddMonths(1);
+
+            Expression<Func<Order, bool>> expression = x => x.CreatedAt >= startDate && x.CreatedAt <= endDate;
+            IQueryPredicateExpressionVisitor queryPredicateExpressionVisitor = this.linqFixture.GetService<IQueryPredicateExpressionVisitor>();
+            string result = queryPredicateExpressionVisitor.Render(expression);
+            Assert.Equal("createdAt >= \"2020-11-21\" and createdAt <= \"2020-12-21\"", result);
+        }
     }
 }

--- a/commercetools.Sdk/commercetools.Sdk.Linq/Query/Converters/ConstantPredicateVisitorConverter.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Linq/Query/Converters/ConstantPredicateVisitorConverter.cs
@@ -38,6 +38,11 @@ namespace commercetools.Sdk.Linq.Query.Converters
                 result = enumResult.GetDescription();
             }
 
+            if (compiledValue is DateTime dateTime)
+            {
+                return new ConstantPredicateVisitor(dateTime.ToUtcIso8601(true).WrapInQuotes());
+            }
+
             if (memberExpression?.Type == typeof(string) || typeof(Enum).IsAssignableFrom(memberExpression?.Type))
             {
                 result = result.WrapInQuotes();


### PR DESCRIPTION
This should fix when querying with date times.

I don't know if this is the right way to approach, but I was giving it a try anyways.

This merges into @MicheleRezk branch so he can merge it all at once

Fixes #110 