### PR TITLE
Convert Reference props to be IReference

### DIFF
--- a/commercetools.Sdk/IntegrationTests/commercetools.Sdk.IntegrationTests/Payments/PaymentsFixture.cs
+++ b/commercetools.Sdk/IntegrationTests/commercetools.Sdk.IntegrationTests/Payments/PaymentsFixture.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using commercetools.Sdk.Client;
 using commercetools.Sdk.Domain;
+using commercetools.Sdk.Domain.Customers;
 using commercetools.Sdk.Domain.Payments;
 using Type = commercetools.Sdk.Domain.Types.Type;
 using static commercetools.Sdk.IntegrationTests.GenericFixture;
@@ -29,6 +30,12 @@ namespace commercetools.Sdk.IntegrationTests.Payments
         {
             var paymentDraft = DefaultPaymentDraft(draft);
             paymentDraft.Transactions = new List<TransactionDraft> { transactionDraft };
+            return paymentDraft;
+        }
+        public static PaymentDraft DefaultPaymentDraftWithCustomer(PaymentDraft draft, Customer customer)
+        {
+            var paymentDraft = DefaultPaymentDraft(draft);
+            paymentDraft.Customer = customer.ToReference() as Reference<Customer>;
             return paymentDraft;
         }
         public static PaymentDraft DefaultPaymentDraftWithCustomType(PaymentDraft draft, Type type, Fields fields)

--- a/commercetools.Sdk/IntegrationTests/commercetools.Sdk.IntegrationTests/Payments/PaymentsIntegrationTests.cs
+++ b/commercetools.Sdk/IntegrationTests/commercetools.Sdk.IntegrationTests/Payments/PaymentsIntegrationTests.cs
@@ -108,6 +108,22 @@ namespace commercetools.Sdk.IntegrationTests.Payments
                     );
                 });
         }
+        
+        [Fact]
+        public async Task CreatePaymentWithCustomer()
+        {
+            await WithCustomer(client, async customer =>
+            {
+                await WithPayment(
+                    client, 
+                    paymentDraft => DefaultPaymentDraftWithCustomer(paymentDraft, customer),
+                    payment =>
+                    {
+                        Assert.NotNull(payment);
+                        Assert.Equal(customer.Id, payment.Customer.Id);
+                    });
+            });
+        }
 
         #region UpdateActions
 

--- a/commercetools.Sdk/commercetools.Sdk.Domain/Carts/LineItemDraft.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Domain/Carts/LineItemDraft.cs
@@ -1,4 +1,5 @@
 ﻿using commercetools.Sdk.Domain.Channels;
+using commercetools.Sdk.Domain.Common;
 
 namespace commercetools.Sdk.Domain.Carts
 {
@@ -12,9 +13,9 @@ namespace commercetools.Sdk.Domain.Carts
 
         public long Quantity { get; set; }
 
-        public Reference<Channel> SupplyChannel { get; set; }
+        public IReference<Channel> SupplyChannel { get; set; }
 
-        public Reference<Channel> DistributionChannel { get; set; }
+        public IReference<Channel> DistributionChannel { get; set; }
 
         public ExternalTaxRateDraft ExternalTaxRate { get; set; }
 

--- a/commercetools.Sdk/commercetools.Sdk.Domain/Carts/UpdateActions/AddLineItemUpdateAction.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Domain/Carts/UpdateActions/AddLineItemUpdateAction.cs
@@ -1,4 +1,5 @@
 ﻿using commercetools.Sdk.Domain.Channels;
+using commercetools.Sdk.Domain.Common;
 
 namespace commercetools.Sdk.Domain.Carts.UpdateActions
 {
@@ -14,9 +15,9 @@ namespace commercetools.Sdk.Domain.Carts.UpdateActions
 
         public long Quantity { get; set; }
 
-        public Reference<Channel> SupplyChannel { get; set; }
+        public IReference<Channel> SupplyChannel { get; set; }
 
-        public Reference<Channel> DistributionChannel { get; set; }
+        public IReference<Channel> DistributionChannel { get; set; }
 
         public ExternalTaxRateDraft ExternalTaxRate { get; set; }
 


### PR DESCRIPTION
Convert Reference props to be IReference in these models:
1. LineItemDraft
2. AddLineItemUpdateAction