### PR TITLE
add example for .NET framework 4.6.1

### DIFF
--- a/commercetools.Sdk/Examples/commercetools.Sdk.Framework461Example/Program.cs
+++ b/commercetools.Sdk/Examples/commercetools.Sdk.Framework461Example/Program.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using commercetools.Sdk.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace commercetools.Sdk.Framework461Example
+{
+  internal class Program
+  {
+    public static void Main(string[] args)
+    {
+      var configuration = new ConfigurationBuilder().
+        AddJsonFile("appsettings.test.json").
+        AddJsonFile("appsettings.test.Development.json", true).
+        // https://www.jerriepelser.com/blog/aspnet-core-no-more-worries-about-checking-in-secrets/
+        AddEnvironmentVariables("CTP_").
+        Build();
+      var services = new ServiceCollection();
+      services.UseCommercetools(configuration, "Client");
+
+      var c = services.BuildServiceProvider();
+
+      var client = c.GetService<IClient>();
+
+      var project = client.ExecuteAsync(new GetProjectCommand()).Result;
+      Console.Out.WriteLine($"Project key: {project.Key}");
+    }
+  }
+}

--- a/commercetools.Sdk/Examples/commercetools.Sdk.Framework461Example/Properties/AssemblyInfo.cs
+++ b/commercetools.Sdk/Examples/commercetools.Sdk.Framework461Example/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("commercetools.Sdk.Framework461Example")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("commercetools.Sdk.Framework461Example")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("E41DE5B7-6D41-4C0E-A0C6-4B788C49159B")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/commercetools.Sdk/Examples/commercetools.Sdk.Framework461Example/appsettings.test.json
+++ b/commercetools.Sdk/Examples/commercetools.Sdk.Framework461Example/appsettings.test.json
@@ -1,0 +1,27 @@
+{
+  "Container": "BuiltIn",
+  "Client": {
+    "ClientId": "",
+    "ClientSecret": "",
+    "Scope": "manage_project:portablevendor",
+    "ProjectKey": "portablevendor"
+  },
+  "TokenClient": {
+    "ClientId": "",
+    "ClientSecret": "",
+    "Scope": "manage_project:portablevendor",
+    "ProjectKey": "portablevendor"
+  },
+  "TokenClientWithSmallerScope": {
+    "ClientId": "",
+    "ClientSecret": "",
+    "Scope": "view_products:portablevendor",
+    "ProjectKey": "portablevendor"
+  },
+  "TokenClientWithAnonymousScope": {
+    "ClientId": "",
+    "ClientSecret": "",
+    "Scope": "view_products:portablevendor",
+    "ProjectKey": "portablevendor"
+  }
+}

--- a/commercetools.Sdk/Examples/commercetools.Sdk.Framework461Example/commercetools.Sdk.Framework461Example.csproj
+++ b/commercetools.Sdk/Examples/commercetools.Sdk.Framework461Example/commercetools.Sdk.Framework461Example.csproj
@@ -1,0 +1,203 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{E41DE5B7-6D41-4C0E-A0C6-4B788C49159B}</ProjectGuid>
+        <OutputType>Exe</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>commercetools.Sdk.Framework461Example</RootNamespace>
+        <AssemblyName>commercetools.Sdk.Framework461Example</AssemblyName>
+        <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+        <FileAlignment>512</FileAlignment>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\</OutputPath>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+          <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.1\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.Configuration, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.Configuration.3.1.6\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Abstractions.3.1.6\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Binder.3.1.6\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.3.1.6\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.Configuration.FileExtensions, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.Configuration.FileExtensions.3.1.6\lib\netstandard2.0\Microsoft.Extensions.Configuration.FileExtensions.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.Configuration.Json, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Json.3.1.6\lib\netstandard2.0\Microsoft.Extensions.Configuration.Json.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.DependencyInjection, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.3.1.6\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.3.1.6\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.FileProviders.Abstractions.3.1.6\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.FileProviders.Physical, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.FileProviders.Physical.3.1.6\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Physical.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.FileSystemGlobbing, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.FileSystemGlobbing.3.1.6\lib\netstandard2.0\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.Http, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.Http.3.1.6\lib\netstandard2.0\Microsoft.Extensions.Http.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.Logging, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.Logging.3.1.6\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.3.1.6\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.Options, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.Options.3.1.6\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.Primitives, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+          <HintPath>..\..\packages\Microsoft.Extensions.Primitives.3.1.6\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="mscorlib" />
+        <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+          <HintPath>..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="System" />
+        <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+          <HintPath>..\..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <HintPath>..\..\packages\System.ComponentModel.Annotations.4.7.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="System.ComponentModel.DataAnnotations" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+          <HintPath>..\..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="System.Numerics" />
+        <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <HintPath>..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="System.Text.Encodings.Web, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+          <HintPath>..\..\packages\System.Text.Encodings.Web.4.7.1\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+          <HintPath>..\..\packages\System.Text.Json.4.7.2\lib\net461\System.Text.Json.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+          <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+          <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="System.Xml" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="Program.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+    </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\..\commercetools.Sdk.Client\commercetools.Sdk.Client.csproj">
+        <Project>{9b105327-3d7d-4857-9811-50f355a4dc2c}</Project>
+        <Name>commercetools.Sdk.Client</Name>
+      </ProjectReference>
+      <ProjectReference Include="..\..\commercetools.Sdk.DependencyInjection\commercetools.Sdk.DependencyInjection.csproj">
+        <Project>{d7492547-921f-49e4-8689-c964cbc0d38e}</Project>
+        <Name>commercetools.Sdk.DependencyInjection</Name>
+      </ProjectReference>
+      <ProjectReference Include="..\..\commercetools.Sdk.Domain\commercetools.Sdk.Domain.csproj">
+        <Project>{1fd56d94-38dc-419b-99c4-9e321d062827}</Project>
+        <Name>commercetools.Sdk.Domain</Name>
+      </ProjectReference>
+      <ProjectReference Include="..\..\commercetools.Sdk.HttpApi\commercetools.Sdk.HttpApi.csproj">
+        <Project>{9b343966-3ba2-4377-8d17-a35d1d630976}</Project>
+        <Name>commercetools.Sdk.HttpApi</Name>
+      </ProjectReference>
+      <ProjectReference Include="..\..\commercetools.Sdk.Registration\commercetools.Sdk.Registration.csproj">
+        <Project>{b3802bff-e732-409a-ab63-ac58d3846bb0}</Project>
+        <Name>commercetools.Sdk.Registration</Name>
+      </ProjectReference>
+      <ProjectReference Include="..\..\commercetools.Sdk.Serialization\commercetools.Sdk.Serialization.csproj">
+        <Project>{04694bae-534b-44eb-89d4-c8e90b5fd59b}</Project>
+        <Name>commercetools.Sdk.Serialization</Name>
+      </ProjectReference>
+    </ItemGroup>
+    <ItemGroup>
+      <None Include="packages.config" />
+    </ItemGroup>
+    <ItemGroup>
+      <Content Include="appsettings.test.Development.json">
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Include="appsettings.test.json">
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+         Other similar extension points exist, see Microsoft.Common.targets.
+    <Target Name="BeforeBuild">
+    </Target>
+    <Target Name="AfterBuild">
+    </Target>
+    -->
+
+</Project>

--- a/commercetools.Sdk/Examples/commercetools.Sdk.Framework461Example/packages.config
+++ b/commercetools.Sdk/Examples/commercetools.Sdk.Framework461Example/packages.config
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.1" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Configuration" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Configuration.FileExtensions" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Configuration.Json" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.FileProviders.Physical" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.FileSystemGlobbing" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Http" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Logging" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Options" version="3.1.6" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Primitives" version="3.1.6" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
+  <package id="System.ComponentModel.Annotations" version="4.7.0" targetFramework="net461" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net461" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net461" />
+  <package id="System.Text.Encodings.Web" version="4.7.1" targetFramework="net461" />
+  <package id="System.Text.Json" version="4.7.2" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
The SDK targets netstandard 2.0 which is supported by .NET Framework 4.6.1. As a PoC i added a small example to use the SDK in this setting.

The project file is not added to the Solution to avoid issues in the build process