### PR TITLE
chore(docs): update naming to match new branding initiative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-# commercetools .NET Core SDK
+# Composable Commerce .NET Core SDK
 
-:warning: **This commercetools .NET Core SDK is in its Active Support mode currently, and is planned to be deprecated, please note the following dates.
+:warning: **This Composable Commerce .NET Core SDK is in its Active Support mode currently, and is planned to be deprecated, please note the following dates.
 
 | Active Support        | Maintenance Support   | End of Life           |
 | --------------------- | --------------------- | --------------------- |
@@ -15,7 +15,7 @@ We recommend to use our [.NET Core SDK V2](https://docs.commercetools.com/sdk/do
 [![AppVeyor Build Status](https://img.shields.io/appveyor/ci/commercetools/commercetools-dotnet-core-sdk.svg)](https://ci.appveyor.com/project/commercetools/commercetools-dotnet-core-sdk)
 [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.All?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.All)
 
-The commercetools .NET Core SDK enables developers to easily communicate with the [commercetools HTTP API](https://docs.commercetools.com/http-api.html). The developers do not need to create plain HTTP requests, but they can instead use the domain specific classes and methods to formulate valid requests.
+The Composable Commerce .NET Core SDK enables developers to easily communicate with the [HTTP API](https://docs.commercetools.com/http-api.html). The developers do not need to create plain HTTP requests, but they can instead use the domain specific classes and methods to formulate valid requests.
 
 ## Installation
 
@@ -28,7 +28,7 @@ The commercetools .NET Core SDK enables developers to easily communicate with th
 The SDK consists of the following projects:
 * `commercetools.Sdk.Client`: Contains abstract commands which are used to create instances of HTTP API commands. Some commands are implemented as generic types and you must specify a domain object when using them, whereas others are specific to a domain object.
 * `commercetools.Sdk.DependencyInjection`: Default entry point to start using the SDK. Contains one class, `DependencyInjectionSetup`, which initializes all services the SDK uses and injects them into the service collection.
-* `commercetools.Sdk.Domain`: Models commercetools domain objects.
+* `commercetools.Sdk.Domain`: Models Composable Commerce domain objects.
 * `commercetools.Sdk.HttpApi`: Communicates directly with the HTTP API.
 	* `Client`: Has one method, `ExecuteAsync()`, which executes commands. Executes commands which calls the HTTP API. Takes commands from classes in the `commercetools.Sdk.Client` project to construct implementations of the `IHttpApiCommand` interface.
 	* `IHttpApiCommand`: Classes implementing this interface are containers for a command from a `commercetools.Sdk.Client` class and a request builder which builds the request to the HTTP API endpoint.
@@ -70,7 +70,7 @@ If other values should be set, the following method overload can be used:
 ```c#
 services.UseCommercetools(
     this.configuration, // replace with your instance of IConfiguration
-    "Client", // replace with your name of the commercetools configuration section
+    "Client", // replace with your name of the Composable Commerce configuration section
     TokenFlow.AnonymousSession); // replace with your initial token flow
 ```
 
@@ -200,7 +200,7 @@ Category category = await this.client
                                 .Builder()
                                 .Categories()
                                 .GetById(id)
-                                .ExecuteAsync(); 
+                                .ExecuteAsync();
 ```
 > Note! For more examples of command builders you can check integration tests in [CustomersIntegrationTestsUsingCommandBuilder](/commercetools.Sdk/IntegrationTests/commercetools.Sdk.IntegrationTests/Customers).
 

--- a/commercetools.Sdk/commercetools.Sdk.All/commercetools.Sdk.All.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.All/commercetools.Sdk.All.csproj
@@ -6,7 +6,7 @@
         <authors>commercetools</authors>
         <owners>commercetools</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</description>
+        <description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</description>
         <copyright>Copyright commercetools 2019</copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</PackageProjectUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/commercetools.Sdk/commercetools.Sdk.Client/commercetools.Sdk.Client.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.Client/commercetools.Sdk.Client.csproj
@@ -7,14 +7,14 @@
     <authors>commercetools</authors>
     <owners>commercetools</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</description>
+    <description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</description>
     <copyright>Copyright commercetools 2019</copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk/master/ct-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</RepositoryUrl>
     <PackageReleaseNotes>Information about latest changes can be found at https://github.com/commercetools/commercetools-dotnet-core-sdk/blob/master/CHANGELOG.md</PackageReleaseNotes>
-    <PackageTags>commercetools;dotnet-core;sdk</PackageTags>
+    <PackageTags>commercetools;composable-commerce;dotnet-core;sdk</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/commercetools.Sdk/commercetools.Sdk.DependencyInjection/DependencyInjectionSetup.cs
+++ b/commercetools.Sdk/commercetools.Sdk.DependencyInjection/DependencyInjectionSetup.cs
@@ -13,7 +13,7 @@ using System.Linq;
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
-    /// Contains extensions methods to use when setting up commercetools dependencies.
+    /// Contains extensions methods to use when setting up Composable Commerce dependencies.
     /// </summary>
     public static class DependencyInjectionSetup
     {

--- a/commercetools.Sdk/commercetools.Sdk.DependencyInjection/commercetools.Sdk.DependencyInjection.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.DependencyInjection/commercetools.Sdk.DependencyInjection.csproj
@@ -5,14 +5,14 @@
     <authors>commercetools</authors>
     <owners>commercetools</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</description>
+    <description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</description>
     <copyright>Copyright commercetools 2019</copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk/master/ct-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</RepositoryUrl>
     <PackageReleaseNotes>Information about latest changes can be found at https://github.com/commercetools/commercetools-dotnet-core-sdk/blob/master/CHANGELOG.md</PackageReleaseNotes>
-    <PackageTags>commercetools;dotnet-core;sdk</PackageTags>
+    <PackageTags>commercetools;composable-commerce;dotnet-core;sdk</PackageTags>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/commercetools.Sdk/commercetools.Sdk.Domain/commercetools.Sdk.Domain.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.Domain/commercetools.Sdk.Domain.csproj
@@ -6,17 +6,17 @@
     <authors>commercetools</authors>
     <owners>commercetools</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</description>
+    <description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</description>
     <copyright>Copyright commercetools 2019</copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk/master/ct-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</RepositoryUrl>
     <PackageReleaseNotes>Information about latest changes can be found at https://github.com/commercetools/commercetools-dotnet-core-sdk/blob/master/CHANGELOG.md</PackageReleaseNotes>
-    <PackageTags>commercetools;dotnet-core;sdk</PackageTags>
+    <PackageTags>commercetools;composable-commerce;dotnet-core;sdk</PackageTags>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <NoWarn>612</NoWarn>
   </PropertyGroup>

--- a/commercetools.Sdk/commercetools.Sdk.HttpApi.Domain/Exceptions/ForbiddenException.cs
+++ b/commercetools.Sdk/commercetools.Sdk.HttpApi.Domain/Exceptions/ForbiddenException.cs
@@ -1,15 +1,15 @@
 namespace commercetools.Sdk.HttpApi.Domain.Exceptions
 {
     /// <summary>
-    /// The commercetools platform received the request but refuses to process it, typically to insufficient rights.
+    /// Composable Commerce received the request but refuses to process it, typically to insufficient rights.
     /// For example it happens if an access token has been received to view products but a request to the customers endpoint is requested.
     /// </summary>
     /// <seealso cref="commercetools.Sdk.HttpApi.Domain.Exceptions.ClientErrorException" />
     public class ForbiddenException : ClientErrorException
     {
         public override int StatusCode => 403;
-        
-        public ForbiddenException() 
+
+        public ForbiddenException()
         {
         }
     }

--- a/commercetools.Sdk/commercetools.Sdk.HttpApi.Domain/Exceptions/InvalidTokenException.cs
+++ b/commercetools.Sdk/commercetools.Sdk.HttpApi.Domain/Exceptions/InvalidTokenException.cs
@@ -2,14 +2,14 @@ namespace commercetools.Sdk.HttpApi.Domain.Exceptions
 {
     /// <summary>
     /// Invalid token for request (401)
-    /// Exception raised in case the access token is not valid for the used commercetools platform project.
+    /// Exception raised in case the access token is not valid for the used Composable Commerce Project.
     /// </summary>
     /// <seealso cref="commercetools.Sdk.HttpApi.Domain.Exceptions.UnauthorizedException" />
     public class InvalidTokenException : UnauthorizedException
     {
         public override int StatusCode => 401;
-        
-        public InvalidTokenException() 
+
+        public InvalidTokenException()
         {
         }
     }

--- a/commercetools.Sdk/commercetools.Sdk.HttpApi.Domain/Exceptions/UnauthorizedException.cs
+++ b/commercetools.Sdk/commercetools.Sdk.HttpApi.Domain/Exceptions/UnauthorizedException.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 namespace commercetools.Sdk.HttpApi.Domain.Exceptions
 {
     /// <summary>
-    /// Unauthorized access to the commercetools platform with either invalid client credentials or tokens.
+    /// Unauthorized access to Composable Commerce with either invalid client credentials or tokens.
     /// Most likely the subclass exceptions InvalidTokenException will be thrown.
     /// </summary>
     /// <seealso cref="commercetools.Sdk.HttpApi.Domain.Exceptions.InvalidTokenException" />
@@ -13,7 +13,7 @@ namespace commercetools.Sdk.HttpApi.Domain.Exceptions
 
         public UnauthorizedException()
         {
-            
+
         }
     }
 }

--- a/commercetools.Sdk/commercetools.Sdk.HttpApi.Domain/commercetools.Sdk.HttpApi.Domain.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.HttpApi.Domain/commercetools.Sdk.HttpApi.Domain.csproj
@@ -6,14 +6,14 @@
     <authors>commercetools</authors>
     <owners>commercetools</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</description>
+    <description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</description>
     <copyright>Copyright commercetools 2019</copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk/master/ct-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</RepositoryUrl>
     <PackageReleaseNotes>Information about latest changes can be found at https://github.com/commercetools/commercetools-dotnet-core-sdk/blob/master/CHANGELOG.md</PackageReleaseNotes>
-    <PackageTags>commercetools;dotnet-core;sdk</PackageTags>
+    <PackageTags>commercetools;composable-commerce;dotnet-core;sdk</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/commercetools.Sdk/commercetools.Sdk.HttpApi/commercetools.Sdk.HttpApi.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.HttpApi/commercetools.Sdk.HttpApi.csproj
@@ -7,14 +7,14 @@
     <authors>commercetools</authors>
     <owners>commercetools</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</description>
+    <description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</description>
     <copyright>Copyright commercetools 2019</copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk/master/ct-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</RepositoryUrl>
     <PackageReleaseNotes>Information about latest changes can be found at https://github.com/commercetools/commercetools-dotnet-core-sdk/blob/master/CHANGELOG.md</PackageReleaseNotes>
-    <PackageTags>commercetools;dotnet-core;sdk</PackageTags>
+    <PackageTags>commercetools;composable-commerce;dotnet-core;sdk</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/commercetools.Sdk/commercetools.Sdk.Linq/commercetools.Sdk.Linq.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.Linq/commercetools.Sdk.Linq.csproj
@@ -7,14 +7,14 @@
     <authors>commercetools</authors>
     <owners>commercetools</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</description>
+    <description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</description>
     <copyright>Copyright commercetools 2019</copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk/master/ct-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</RepositoryUrl>
     <PackageReleaseNotes>Information about latest changes can be found at https://github.com/commercetools/commercetools-dotnet-core-sdk/blob/master/CHANGELOG.md</PackageReleaseNotes>
-    <PackageTags>commercetools;dotnet-core;sdk</PackageTags>
+    <PackageTags>commercetools;composable-commerce;dotnet-core;sdk</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/commercetools.Sdk/commercetools.Sdk.NodaMoney/commercetools.Sdk.NodaMoney.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.NodaMoney/commercetools.Sdk.NodaMoney.csproj
@@ -7,14 +7,14 @@
         <authors>commercetools</authors>
         <owners>commercetools</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</description>
+        <description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</description>
         <copyright>Copyright commercetools 2019</copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</PackageProjectUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk/master/ct-logo.png</PackageIconUrl>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</RepositoryUrl>
         <PackageReleaseNotes>Information about latest changes can be found at https://github.com/commercetools/commercetools-dotnet-core-sdk/blob/master/CHANGELOG.md</PackageReleaseNotes>
-        <PackageTags>commercetools;dotnet-core;sdk</PackageTags>
+        <PackageTags>commercetools;composable-commerce;dotnet-core;sdk</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>

--- a/commercetools.Sdk/commercetools.Sdk.Registration/commercetools.Sdk.Registration.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.Registration/commercetools.Sdk.Registration.csproj
@@ -7,14 +7,14 @@
     <authors>commercetools</authors>
     <owners>commercetools</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</description>
+    <description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</description>
     <copyright>Copyright commercetools 2019</copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk/master/ct-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</RepositoryUrl>
     <PackageReleaseNotes>Information about latest changes can be found at https://github.com/commercetools/commercetools-dotnet-core-sdk/blob/master/CHANGELOG.md</PackageReleaseNotes>
-    <PackageTags>commercetools;dotnet-core;sdk</PackageTags>
+    <PackageTags>commercetools;composable-commerce;dotnet-core;sdk</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/commercetools.Sdk/commercetools.Sdk.Serialization/commercetools.Sdk.Serialization.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.Serialization/commercetools.Sdk.Serialization.csproj
@@ -6,14 +6,14 @@
     <authors>commercetools</authors>
     <owners>commercetools</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</description>
+    <description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</description>
     <copyright>Copyright commercetools 2019</copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk/master/ct-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</RepositoryUrl>
     <PackageReleaseNotes>Information about latest changes can be found at https://github.com/commercetools/commercetools-dotnet-core-sdk/blob/master/CHANGELOG.md</PackageReleaseNotes>
-    <PackageTags>commercetools;dotnet-core;sdk</PackageTags>
+    <PackageTags>commercetools;composable-commerce;dotnet-core;sdk</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/commercetools.Sdk/commercetools.Sdk.SimpleInjector/commercetools.Sdk.SimpleInjector.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.SimpleInjector/commercetools.Sdk.SimpleInjector.csproj
@@ -6,14 +6,14 @@
         <authors>commercetools</authors>
         <owners>commercetools</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</description>
+        <description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</description>
         <copyright>Copyright commercetools 2019</copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</PackageProjectUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk/master/ct-logo.png</PackageIconUrl>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</RepositoryUrl>
         <PackageReleaseNotes>Information about latest changes can be found at https://github.com/commercetools/commercetools-dotnet-core-sdk/blob/master/CHANGELOG.md</PackageReleaseNotes>
-        <PackageTags>commercetools;dotnet-core;sdk</PackageTags>
+        <PackageTags>commercetools;composable-commerce;dotnet-core;sdk</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>

--- a/commercetools.Sdk/commercetools.Sdk.Validation/commercetools.Sdk.Validation.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.Validation/commercetools.Sdk.Validation.csproj
@@ -6,14 +6,14 @@
         <authors>commercetools</authors>
         <owners>commercetools</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</description>
+        <description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</description>
         <copyright>Copyright commercetools 2019</copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</PackageProjectUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk/master/ct-logo.png</PackageIconUrl>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk</RepositoryUrl>
         <PackageReleaseNotes>Information about latest changes can be found at https://github.com/commercetools/commercetools-dotnet-core-sdk/blob/master/CHANGELOG.md</PackageReleaseNotes>
-        <PackageTags>commercetools;dotnet-core;sdk</PackageTags>
+        <PackageTags>commercetools;composable-commerce;dotnet-core;sdk</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
# Description
This PR follows the rebranding initiative by the Marketing and Docs team to change commercetools to Composable Commerce.

https://github.com/commercetools/clients-team-internal/issues/87

NB: This PR does not update the tests, as this is out of scope.